### PR TITLE
Adapt to Flux.jl > v0.13

### DIFF
--- a/src/dueling.jl
+++ b/src/dueling.jl
@@ -10,7 +10,7 @@ function (m::DuelingNetwork)(inpt)
     return m.val(x) .+ m.adv(x) .- mean(m.adv(x), dims=1)
 end
 
-Flux.@functor DuelingNetwork
+Flux.@layer DuelingNetwork
 
 function Flux.reset!(m::DuelingNetwork)
     Flux.reset!(m.base)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -140,8 +140,7 @@ function dqn_train!(solver::DeepQLearningSolver, env::AbstractEnv, policy::Abstr
         end
 
         if t%solver.target_update_freq == 0
-            weights = Flux.params(active_q)
-            Flux.loadparams!(target_q, weights)
+            Flux.loadmodel!(target_q, active_q)
         end
 
         if t % solver.eval_freq == 0
@@ -171,7 +170,7 @@ function dqn_train!(solver::DeepQLearningSolver, env::AbstractEnv, policy::Abstr
         if solver.verbose
             @printf("Restore model with eval reward %1.3f \n", saved_mean_reward)
             saved_model = BSON.load(joinpath(solver.logdir, "qnetwork.bson"))[:qnetwork]
-            Flux.loadparams!(getnetwork(policy), saved_model)
+            Flux.loadmodel!(getnetwork(policy), saved_model)
         end
     end
     return policy
@@ -289,7 +288,7 @@ end
 
 function save_model(solver::DeepQLearningSolver, active_q, scores_eval::Float64, saved_mean_reward::Float64, model_saved::Bool)
     if scores_eval >= saved_mean_reward
-        bson(joinpath(solver.logdir, "qnetwork.bson"), qnetwork=[w for w in Flux.params(active_q)])
+        bson(joinpath(solver.logdir, "qnetwork.bson"), qnetwork=active_q)
         if solver.verbose
             @printf("Saving new model with eval reward %1.3f \n", scores_eval)
         end
@@ -312,7 +311,7 @@ function restore_best_model(solver::DeepQLearningSolver, env::AbstractEnv)
     end
     policy = NNPolicy(env, active_q, collect(actions(env)), length(obs_dimensions(env)))
     weights = BSON.load(solver.logdir*"qnetwork.bson")[:qnetwork]
-    Flux.loadparams!(getnetwork(policy), weights)
+    Flux.loadmodel!(getnetwork(policy), weights)
     Flux.testmode!(getnetwork(policy))
     return policy
 end


### PR DESCRIPTION
According to Flux release notes,
https://github.com/FluxML/Flux.jl/blob/cb9bb307b30b9111617e5b28ea1c5398ef3693f3/NEWS.md
version 0.13 replaced `loadparam!` by `loadmodel`, and version 0.14.13 deprecated the macro `@functor` in favor of `Flux.@layer`. This pull request adapts the code for these two changes.