### PR TITLE
Updates to fix issues associated with Flux 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ log*
 events.out.tfevents*
 .vscode
 Manifest.toml
+.DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DeepQLearning"
 uuid = "de0a67f4-c691-11e8-0034-5fc6e16e22d3"
 repo = "https://github.com/JuliaPOMDP/DeepQLearning.jl"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ using DeepQLearning
 using POMDPs
 using Flux
 using POMDPModels
-using POMDPSimulators
 using POMDPTools
 
 # load MDP model from POMDPModels or define your own!
@@ -37,7 +36,7 @@ mdp = SimpleGridWorld();
 # the gridworld state is represented by a 2 dimensional vector.
 model = Chain(Dense(2, 32), Dense(32, length(actions(mdp))))
 
-exploration = EpsGreedyPolicy(mdp, LinearDecaySchedule(start=1.0, stop=0.01, steps=10000/2))
+exploration = EpsGreedyPolicy(mdp, LinearDecaySchedule(start=1.0, stop=0.01, steps=10000/2));
 
 solver = DeepQLearningSolver(qnetwork = model, max_steps=10000, 
                              exploration_policy = exploration,
@@ -99,9 +98,12 @@ mdp = SimpleGridWorld();
 # the model weights will be send to the gpu in the call to solve
 model = Chain(Dense(2, 32), Dense(32, length(actions(mdp))))
 
-solver = DeepQLearningSolver(qnetwork = model, max_steps=10000, 
-                             learning_rate=0.005,log_freq=500,
-                             recurrence=false,double_q=true, dueling=true, prioritized_replay=true)
+exploration = EpsGreedyPolicy(mdp, LinearDecaySchedule(start=1.0, stop=0.01, steps=10000/2));
+
+solver = DeepQLearningSolver(qnetwork=model, max_steps=10000, 
+                            exploration_policy=exploration,
+                            learning_rate=0.005,log_freq=500,
+                            recurrence=false,double_q=true, dueling=true, prioritized_replay=true)
 policy = solve(solver, mdp)
 ```
 
@@ -109,19 +111,18 @@ policy = solve(solver, mdp)
 
 **Fields of the Q Learning solver:**
 - `qnetwork::Any = nothing` Specify the architecture of the Q network 
+- `exploration_policy::<ExplorationPolicy` Exploration strategy (e.g. EpsGreedyPolicy)
 - `learning_rate::Float64 = 1e-4` learning rate 
 - `max_steps::Int64` total number of training step default = 1000
-- `target_update_freq::Int64` frequency at which the target network is updated default = 500
 - `batch_size::Int64` batch size sampled from the replay buffer default = 32
 - `train_freq::Int64` frequency at which the active network is updated default  = 4
-- `log_freq::Int64` frequency at which to logg info default = 100
 - `eval_freq::Int64` frequency at which to eval the network default = 100
+- `target_update_freq::Int64` frequency at which the target network is updated default = 500
 - `num_ep_eval::Int64` number of episodes to evaluate the policy default = 100
-- `eps_fraction::Float64` fraction of the training set used to explore default = 0.5
-- `eps_end::Float64` value of epsilon at the end of the exploration phase default = 0.01
 - `double_q::Bool` double q learning udpate default = true
 - `dueling::Bool` dueling structure for the q network default = true
 - `recurrence::Bool = false` set to true to use DRQN, it will throw an error if you set it to false and pass a recurrent model.
+- `evaluation_policy::Function = basic_evaluation` function use to evaluate the policy every `eval_freq` steps, the default is a rollout that return the undiscounted average reward 
 - `prioritized_replay::Bool` enable prioritized experience replay default = true
 - `prioritized_replay_alpha::Float64` default = 0.6
 - `prioritized_replay_epsilon::Float64` default = 1e-6
@@ -129,9 +130,8 @@ policy = solve(solver, mdp)
 - `buffer_size::Int64` size of the experience replay buffer default = 1000
 - `max_episode_length::Int64` maximum length of a training episode default = 100
 - `train_start::Int64` number of steps used to fill in the replay buffer initially default = 200
-- `save_freq::Int64` save the model every `save_freq` steps, default = 1000
-- `evaluation_policy::Function = basic_evaluation` function use to evaluate the policy every `eval_freq` steps, the default is a rollout that return the undiscounted average reward 
-- `exploration_policy::Any = linear_epsilon_greedy(max_steps, eps_fraction, eps_end)` exploration strategy (default is epsilon greedy with linear decay)
 - `rng::AbstractRNG` random number generator default = MersenneTwister(0)
 - `logdir::String = ""` folder in which to save the model
+- `save_freq::Int64` save the model every `save_freq` steps, default = 1000
+- `log_freq::Int64` frequency at which to logg info default = 100
 - `verbose::Bool` default = true

--- a/src/dueling.jl
+++ b/src/dueling.jl
@@ -10,7 +10,7 @@ function (m::DuelingNetwork)(inpt)
     return m.val(x) .+ m.adv(x) .- mean(m.adv(x), dims=1)
 end
 
-Flux.@functor DuelingNetwork
+Flux.@layer DuelingNetwork
 
 function Flux.reset!(m::DuelingNetwork)
     Flux.reset!(m.base)

--- a/test/README_examples.jl
+++ b/test/README_examples.jl
@@ -1,0 +1,42 @@
+using DeepQLearning
+using POMDPs
+using Flux
+using POMDPModels
+using POMDPTools
+
+@testset "README Example 1" begin
+    # load MDP model from POMDPModels or define your own!
+    mdp = SimpleGridWorld();
+
+    # Define the Q network (see Flux.jl documentation)
+    # the gridworld state is represented by a 2 dimensional vector.
+    model = Chain(Dense(2, 32), Dense(32, length(actions(mdp))))
+
+    exploration = EpsGreedyPolicy(mdp, LinearDecaySchedule(start=1.0, stop=0.01, steps=10000/2));
+
+    solver = DeepQLearningSolver(qnetwork = model, max_steps=10000, 
+                                exploration_policy = exploration,
+                                learning_rate=0.005,log_freq=500,
+                                recurrence=false,double_q=true, dueling=true, prioritized_replay=true)
+    policy = solve(solver, mdp)
+
+    sim = RolloutSimulator(max_steps=30)
+    r_tot = simulate(sim, mdp, policy)
+    println("Total discounted reward for 1 simulation: $r_tot")
+end
+
+@testset "README Example 2" begin
+    # Without using CuArrays
+    mdp = SimpleGridWorld();
+
+    # the model weights will be send to the gpu in the call to solve
+    model = Chain(Dense(2, 32), Dense(32, length(actions(mdp))))
+
+    exploration = EpsGreedyPolicy(mdp, LinearDecaySchedule(start=1.0, stop=0.01, steps=10000/2));
+    
+    solver = DeepQLearningSolver(qnetwork=model, max_steps=10000, 
+                                exploration_policy=exploration,
+                                learning_rate=0.005,log_freq=500,
+                                recurrence=false,double_q=true, dueling=true, prioritized_replay=true)
+    policy = solve(solver, mdp)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,3 +232,8 @@ end
 
     @test evaluate(env, policy, GLOBAL_RNG) > 1.0
 end
+
+
+@testset "README Examples" begin
+    include("README_examples.jl")
+end


### PR DESCRIPTION
Addresses and closes 

- https://github.com/JuliaPOMDP/DeepQLearning.jl/issues/75
- https://github.com/JuliaPOMDP/DeepQLearning.jl/issues/73
- https://github.com/JuliaPOMDP/DeepQLearning.jl/issues/67

Starting from https://github.com/JuliaPOMDP/DeepQLearning.jl/pull/74, this PR fixes the remaining issues with moving from `loadparams!` to `loadmodels!` in Flux 0.14 (and later).

The readme was also updated to incorporate changes made in 9ac3abd46d4257cbfc543e9e20b3904b871a85f5. Added tests to incorporate the current README examples (though did not include the usage of CuArrays).

These changes only ensure compatibility with Flux 0.14. Starting with 0.15, Flux significantly changes how the recurrent layers function.